### PR TITLE
Fix typo in node module usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ const options = {
 };
 
 const defaults = Confippet.store();
-defaults._$.compose(configOptions);
+defaults._$.compose(options);
 ```
 
 


### PR DESCRIPTION
# Props

Super excited to use this over confidence and node-config.

# Changes

`configOptions` is not defined: should be `options`

