### PR TITLE
processConfig: don't force string result

### DIFF
--- a/lib/process-config.js
+++ b/lib/process-config.js
@@ -38,16 +38,21 @@ function processObj(obj, data) {
 
       } else {
         const extras = _(refs).drop().map(resolve).value().join("");
-        return `${x}${extras}`;
+        return extras ? `${x}${extras}` : x;
       }
     };
 
-    if (_.isString(v) && _.includes(v, "{{")) {
-      obj[k] = v.replace(/\{\{([^}]+)}}/g, (match, tmpl) => {
-        const newV = resolve(tmpl);
-        data.more += _.includes(newV, "{{") ? 1 : 0;
-        return newV;
-      });
+    if (_.isString(v)) {
+      if (/^\{\{.*}}$/.test(v)) {
+        obj[k] = resolve(v.slice(2, -2));
+        data.more += _.includes(obj[k], '{{') ? 1 : 0;
+      } else if ( _.includes(v, "{{")) {
+        obj[k] = v.replace(/\{\{([^}]+)}}/g, (match, tmpl) => {
+          const newV = resolve(tmpl);
+          data.more += _.includes(newV, "{{") ? 1 : 0;
+          return newV;
+        });
+      }
     }
   });
 }


### PR DESCRIPTION
If the template definition is the whole string, this change allows the result to be any type. That way you can have arrays etc as values from template expansion.

If you like this I can see about adding a test…